### PR TITLE
OMPL Planning Interface did not set bounds automatically

### DIFF
--- a/planning/OMPLInterface.cpp
+++ b/planning/OMPLInterface.cpp
@@ -399,14 +399,18 @@ CSpaceOMPLStateSpace::CSpaceOMPLStateSpace(CSpace* _space,CSpaceOMPLSpaceInforma
 {
   PropertyMap props;
   space->Properties(props);
-  vector<double> minimum,maximum;
   if(props.getArray("minimum",minimum) && props.getArray("maximum",maximum)) {
   }
   else {
     minimum.resize(0);
     maximum.resize(0);
   }
+  ob::RealVectorBounds bounds(minimum.size());
+  bounds.low = minimum;
+  bounds.high = maximum;
+  setBounds(bounds);
 }
+
 
 unsigned int CSpaceOMPLStateSpace::getDimension (void) const
 {


### PR DESCRIPTION
Problem: Calling the OMPL Planning interface did not set the CSpace bounds, error message reads
"terminate called after throwing an instance of 'ompl::Exception'
  what():  Bounds for real vector space seem to be incorrect (lower bound must be stricly less than upper bound). Sampling will not be possible
"

Fix:
In Constructor of CSpaceOMPLStateSpace:
(1) local variables minimum/maximum were overshadowing the class variables minimum/maximum => removed
(2) bounds of the parent class RealVectorStateSpace were not set => setBounds