### PR TITLE
Changed location of glui header to reflect the current homebrew package.

### DIFF
--- a/CMakeModules/FindGLUI.cmake
+++ b/CMakeModules/FindGLUI.cmake
@@ -79,7 +79,7 @@ if(OPENGL_FOUND AND GLUT_FOUND)
 
 		if(APPLE)
 			find_path(GLUI_INCLUDE_DIR
-				GLUI/glui.h
+				GL/glui.h
 				HINTS
 				${OPENGL_INCLUDE_DIR}
 				DOC


### PR DESCRIPTION
Homebrew packages glui.h in include/GL/glui.h. This is causing CMake to set GLUI to not found.