### PR TITLE
Fix compile error from not having GLPK.

### DIFF
--- a/optimization/GLPKInterface.cpp
+++ b/optimization/GLPKInterface.cpp
@@ -347,6 +347,8 @@ bool GLPKInterface::Enabled() { return true; }
 
 #else
 
+#include <iostream>
+
 using namespace Optimization;
 using namespace std;
 


### PR DESCRIPTION
Iostream is not included in the else case so all the cerror messages throw compiler errors.

```/home/tabor/pkgs/KrisLibrary/optimization/GLPKInterface.cpp:363:3: error: ‘cerr’ was not declared in this scope
   cerr<<"Warning, GLPK not defined"<<endl;
   ^
/home/tabor/pkgs/KrisLibrary/optimization/GLPKInterface.cpp:363:38: error: ‘endl’ was not declared in this scope
   cerr<<"Warning, GLPK not defined"<<endl;
                                      ^
/home/tabor/pkgs/KrisLibrary/optimization/GLPKInterface.cpp: In member function ‘void Optimization::GLPKInterface::Set(const Optimization::LinearProgram_Sparse&)’:
/home/tabor/pkgs/KrisLibrary/optimization/GLPKInterface.cpp:368:3: error: ‘cerr’ was not declared in this scope
   cerr<<"Warning, GLPK not defined"<<endl;
   ^
/home/tabor/pkgs/KrisLibrary/optimization/GLPKInterface.cpp:368:38: error: ‘endl’ was not declared in this scope
   cerr<<"Warning, GLPK not defined"<<endl;
```