### PR TITLE
Fix missing include of std::map

### DIFF
--- a/robotics/RobotKinematics3D.cpp
+++ b/robotics/RobotKinematics3D.cpp
@@ -5,6 +5,7 @@
 #include <math/angle.h>
 #include <list>
 #include <queue>
+#include <map>
 using namespace std;
 
 void RobotKinematics3D::Initialize(int numLinks)


### PR DESCRIPTION
When rebuilding klampt with krislibrary, map is not decleared in the scope of ./robotics/RobotKinematics3D.cpp

The build will fail at https://github.com/krishauser/KrisLibrary/blob/a0b1f8af671edf9d536e4513509b7fd66655fde7/robotics/RobotKinematics3D.cpp#L389
This fix resolves the issue.